### PR TITLE
🐛 fix decktape/reveal error when generating pdf for slides

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = (env = {}, argv) => {
           use: [{ loader: MiniCssExtractPlugin.loader }, "css-loader"],
         },
         {
-          test: /reveal\.js[\/\\]js[\/\\]reveal\.js$/,
+          test: /reveal\.js[\/\\]dist[\/\\]reveal\.js$/,
           use: { loader: "expose-loader", options: "Reveal" },
         },
         {


### PR DESCRIPTION
See #11. This was caused by a mistake made while upgrading to Reveal 4 in https://github.com/Zenika/sensei/commit/aacf1ed298f20cbfdfa403abf7efc0b12197c3fb.