### PR TITLE
:sparkles: add more lang on Prismjs highlight

### DIFF
--- a/src/loaders/revealjs-loader.js
+++ b/src/loaders/revealjs-loader.js
@@ -1,6 +1,6 @@
 const marked = require("marked");
 const Prism = require("prismjs");
-require("prismjs/components/prism-clike");
+require("prismjs/components/")();
 
 module.exports = (content) => {
   return slidify(content, {


### PR DESCRIPTION
By default Prismjs do not load all lang and for exemple highlighting not working for typescript.
This new import will load all lang present in prismjs module