### PR TITLE
✨ support reveal's element attribute syntax

### DIFF
--- a/src/loaders/revealjs-loader.js
+++ b/src/loaders/revealjs-loader.js
@@ -127,7 +127,7 @@ function slidify(markdown, options) {
   markdownSections = markdownSections.replace(
     /(<!--\s*\.element:(["=\-\w\s]+)-->\s*)<([^>]+)>/g,
     "$1<$3 $2>"
-  )
+  );
 
   return markdownSections;
 }

--- a/src/loaders/revealjs-loader.js
+++ b/src/loaders/revealjs-loader.js
@@ -48,16 +48,6 @@ var SCRIPT_END_PLACEHOLDER = "__SCRIPT_END__";
 function slidify(markdown, options) {
   options = getSlidifyOptions(options);
 
-  marked.use({
-    renderer: {
-      paragraph(text) {
-        const elClass =
-          getEmbeddedClasses(text, DEFAULT_ELEMENT_ATTRIBUTES_SEPARATOR) || "";
-        return `<p ${elClass}>${text}</p>`;
-      },
-    },
-  });
-
   var separatorRegex = new RegExp(
       options.separator +
         (options.verticalSeparator ? "|" + options.verticalSeparator : ""),
@@ -132,6 +122,12 @@ function slidify(markdown, options) {
         "</section>";
     }
   }
+
+  // Support for the <!-- .element: --> syntax from Reveal (see https://revealjs.com/markdown/#element-attributes)
+  markdownSections = markdownSections.replace(
+    /(<!--\s*\.element:(["=\-\w\s]+)-->\s*)<([^>]+)>/g,
+    "$1<$3 $2>"
+  )
 
   return markdownSections;
 }

--- a/src/loaders/revealjs-loader.js
+++ b/src/loaders/revealjs-loader.js
@@ -48,6 +48,16 @@ var SCRIPT_END_PLACEHOLDER = "__SCRIPT_END__";
 function slidify(markdown, options) {
   options = getSlidifyOptions(options);
 
+  marked.use({
+    renderer: {
+      paragraph(text) {
+        const elClass =
+          getEmbeddedClasses(text, DEFAULT_ELEMENT_ATTRIBUTES_SEPARATOR) || "";
+        return `<p ${elClass}>${text}</p>`;
+      },
+    },
+  });
+
   var separatorRegex = new RegExp(
       options.separator +
         (options.verticalSeparator ? "|" + options.verticalSeparator : ""),


### PR DESCRIPTION
Some formations slides use markdown comment to add attributes on paragraph element.
This is a proposal to preserve the  syntax & compatibility 

Examples : 

```
<!-- .element: style="height: 20%;" -->
```
```
<!-- .element: class="alert alert-warning" -->
```