### PR TITLE
💄 improve compatibility with material using previous theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .nyc_output/
 *.pdf
+/.idea/

--- a/src/slides/slides.css
+++ b/src/slides/slides.css
@@ -207,6 +207,13 @@ body {
   white-space: pre-wrap;
 }
 
+.reveal h2 + pre,
+.reveal h3 + pre {
+  /* Whole-slide code block */
+  border: none;
+  padding-left: 0;
+}
+
 .reveal pre > code,
 .reveal .code {
   color: black;

--- a/src/slides/slides.css
+++ b/src/slides/slides.css
@@ -200,7 +200,7 @@ body {
 .reveal pre {
   margin: var(--content-block-vertical-margin) 0;
   box-shadow: none;
-  border: 1px solid #ddd;
+  border: 1px solid #d9d9d9;
   border-left: 1px solid var(--zenika-red);
   padding: 10px 15px;
   width: 100%;

--- a/src/slides/slides.css
+++ b/src/slides/slides.css
@@ -142,10 +142,10 @@ body {
 
 .reveal h2,
 .reveal h3 {
-  margin-top: 2em;
-  margin-bottom: 0.5em;
+  margin-top: 1.5em;
+  margin-bottom: 1em;
   text-align: left;
-  font-size: 40pt;
+  font-size: 35pt;
 }
 
 .reveal h2::after {
@@ -190,6 +190,7 @@ body {
 
 .reveal blockquote {
   background: rgba(230, 230, 230, 1);
+  padding: 10px 20px;
 }
 
 /*********************************************
@@ -199,17 +200,11 @@ body {
 .reveal pre {
   margin: var(--content-block-vertical-margin) 0;
   box-shadow: none;
+  border: 1px solid #ddd;
   border-left: 1px solid var(--zenika-red);
-  padding-left: 10px;
+  padding: 10px 15px;
   width: 100%;
   white-space: pre-wrap;
-}
-
-.reveal h2 + pre,
-.reveal h3 + pre {
-  /* Whole-slide code block */
-  border: none;
-  padding-left: 0;
 }
 
 .reveal pre > code,
@@ -219,6 +214,7 @@ body {
   font-family: var(--code-font-family);
   font-size: 22px;
   line-height: normal;
+  display: block;
 }
 
 .slides section > section:not([class^="page-"]) {

--- a/src/slides/slides.html
+++ b/src/slides/slides.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Webpack App</title>
+    <title>Zenika Formation</title>
   </head>
   <body>
     <div class="reveal">


### PR DESCRIPTION
After trying to use `sensei` on `Angular avancé` training, slides doesn't display well because of header and code block. So I add some ajustements and improvements to style and keep compatibility.

- Reduce header size and margin
- Add `display: block` on code block to reduce `line-height`
- Improve code block visibility
- Remove specific rule for whole-slide code block (not sure to understand goal of this rule ?)