### PR TITLE
💄 Highlight external links

### DIFF
--- a/src/slides/slides.css
+++ b/src/slides/slides.css
@@ -420,6 +420,12 @@ body:lang(en) {
   transition: color 0.15s ease;
 }
 
+.reveal a[href^="http://"], .reveal a[href^="https://"]
+{
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
 .reveal a:not(.image):hover {
   color: var(--zenika-red);
   text-shadow: none;


### PR DESCRIPTION
Currently it's not distinct from 'em' elements

Without:
![image](https://user-images.githubusercontent.com/175128/93979010-126b9080-fd7d-11ea-934c-d7ac51848fb5.png)

With:
![image](https://user-images.githubusercontent.com/175128/93979061-257e6080-fd7d-11ea-873a-da1b9a9b8482.png)

Used to do something like that in the K8S training:
![image](https://user-images.githubusercontent.com/175128/93979231-5bbbe000-fd7d-11ea-98af-982dba4a4f61.png)
