### PR TITLE
💄 Highlight table headers with bold

### DIFF
--- a/src/slides/slides.css
+++ b/src/slides/slides.css
@@ -95,7 +95,7 @@ body:lang(en) {
 }
 
 .reveal .slides table th {
-  font-weight: normal;
+  font-weight: bold;
 }
 
 .reveal .slides table tr td {


### PR DESCRIPTION
This way, the header is highlighted a bit more than just with the thin red line.

Before: ![image](https://user-images.githubusercontent.com/175128/94420476-80042c00-0184-11eb-93b2-b82f35875a0b.png)

After: ![image](https://user-images.githubusercontent.com/175128/94420556-9f02be00-0184-11eb-8f1d-11d810184a81.png)

