### PR TITLE
💄 change copyright color for a lighter gray

### DIFF
--- a/src/slides/slides.css
+++ b/src/slides/slides.css
@@ -533,7 +533,6 @@ body:lang(en) {
   font-size: 70%;
   /* unset styles from Reveal */
   background-color: unset;
-  color: unset;
   font-family: unset;
   padding: unset;
 }
@@ -553,6 +552,7 @@ body:lang(en) {
 
 .reveal .slides footer.slide-number {
   left: 50px;
+  color: unset;
 }
 
 /*********************************************


### PR DESCRIPTION
Proposal for change copyright color in favor of a lighter gray to set a little less visible

**Previous:** 
<img width="1644" alt="previous gray" src="https://user-images.githubusercontent.com/6205002/94859630-20807780-0435-11eb-8390-91d71ee4e34e.png">

**Proposal:**
<img width="1620" alt="gray_copyright" src="https://user-images.githubusercontent.com/6205002/94859511-ee6f1580-0434-11eb-925d-32d2449da299.png">
