### PR TITLE
🐛 fix build error when using as dependency

### DIFF
--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+
 const spawn = require("child_process").spawn;
 const fork = require("child_process").fork;
 const path = require("path");
@@ -6,17 +7,17 @@ const WebpackDevServer = require("webpack-dev-server");
 const config = require("../webpack.config");
 const webpack = require("webpack");
 
-function cli(args) {
+async function cli(args) {
   let trainingMaterialFolder = args[3];
   switch (args[2]) {
     case "serve":
       serve(trainingMaterialFolder);
       break;
     case "build":
-      build(trainingMaterialFolder);
+      await build(trainingMaterialFolder);
       break;
     case "pdf":
-      pdf(trainingMaterialFolder);
+      await pdf(trainingMaterialFolder);
       break;
     case "help":
     case "-h":
@@ -150,6 +151,11 @@ process.on("SIGTERM", function onSigterm() {
     new Date().toISOString()
   );
   process.exit();
+});
+
+process.on("unhandledRejection", (err) => {
+  process.exitCode = 1;
+  throw err;
 });
 
 cli(process.argv);

--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -46,13 +46,14 @@ function build(trainingMaterialFolder = ".") {
   console.log("Build slides & labs");
   return new Promise((resolve, reject) => {
     webpack(config({ material: trainingMaterialFolder }), (err, stats) => {
-      if (err || stats.hasErrors()) {
-        console.error("HTML files generation failed!", err);
-        reject();
-      } else {
-        console.log("Files generated to dist folder");
-        resolve();
+      if (err) {
+        return reject(err);
       }
+      if (stats.hasErrors()) {
+        return reject(stats);
+      }
+      console.log("Files generated to dist folder");
+      resolve();
     });
   });
 }

--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -101,7 +101,12 @@ function pdfSlides(trainingName) {
       process.stdout.write(data);
     });
 
-    child.on("exit", function () {
+    child.on("exit", function (code) {
+      if (code !== 0) {
+        return reject(
+          new Error(`spawned process exited with non-zero code '${code}'`)
+        );
+      }
       console.log("PDF slides generated");
       resolve();
     });
@@ -123,7 +128,12 @@ function pdfLabs(trainingName) {
       ]
     );
 
-    child.on("exit", function () {
+    child.on("exit", function (code) {
+      if (code !== 0) {
+        return reject(
+          new Error(`forked process exited with non-zero code '${code}'`)
+        );
+      }
       console.log("PDF labs generated");
       resolve();
     });

--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -50,7 +50,7 @@ function build(trainingMaterialFolder = ".") {
         return reject(err);
       }
       if (stats.hasErrors()) {
-        return reject(stats);
+        return reject(new Error(stats.toString()));
       }
       console.log("Files generated to dist folder");
       resolve();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,14 @@ module.exports = (env = {}, argv) => {
       alias: {
         "training-material": trainingMaterialFolder,
       },
+      symlinks: false,
+      modules: [
+        // this is to support the "npm link" case where imports must be resolved
+        // from the project folder
+        path.resolve(__dirname, "node_modules"),
+        // this is the default and works for most cases
+        "node_modules"
+      ],
     },
     output: {
       path: path.resolve("./dist"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = (env = {}, argv) => {
         "training-material": trainingMaterialFolder,
       },
       symlinks: false,
-      modules: [path.resolve(__dirname, "node_modules"), path.resolve("./")],
+      modules: [path.resolve("./")],
     },
     output: {
       path: path.resolve("./dist"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,7 @@ module.exports = (env = {}, argv) => {
         // from the project folder
         path.resolve(__dirname, "node_modules"),
         // this is the default and works for most cases
-        "node_modules"
+        "node_modules",
       ],
     },
     output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,13 +70,6 @@ module.exports = (env = {}, argv) => {
         },
       ],
     },
-    resolve: {
-      alias: {
-        "training-material": trainingMaterialFolder,
-      },
-      symlinks: false,
-      modules: [path.resolve("./")],
-    },
     output: {
       path: path.resolve("./dist"),
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,6 +70,11 @@ module.exports = (env = {}, argv) => {
         },
       ],
     },
+    resolve: {
+      alias: {
+        "training-material": trainingMaterialFolder,
+      },
+    },
     output: {
       path: path.resolve("./dist"),
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = (env = {}, argv) => {
         "training-material": trainingMaterialFolder,
       },
       symlinks: false,
-      modules: [path.resolve(__dirname, "node_modules")],
+      modules: [path.resolve(__dirname, "node_modules"), path.resolve("./")],
     },
     output: {
       path: path.resolve("./dist"),


### PR DESCRIPTION
See #45 for context of how this was found and how it can be reproduced. Fixes #45.

This fixes Webpack module resolution configuration so that it works correctly in all sensei use cases.

If also improves error handling in the CLI. Errors thrown from the Webpack build or child processes are properly reported, and unhandled promise rejections trigger a non-zero exit code.