### PR TITLE
:sparkles: Add version information in Labs

### DIFF
--- a/src/labs/labs.css
+++ b/src/labs/labs.css
@@ -397,6 +397,13 @@ span.float-right > span {
   text-align: right;
 }
 
+span.version {
+  color: #a0a0a0;
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+}
+
 code[class*="language-"],
 pre[class*="language-"] {
   white-space: pre-wrap;

--- a/src/labs/labs.js
+++ b/src/labs/labs.js
@@ -4,3 +4,11 @@ import labs from "training-material/CahierExercices/parts.json";
 
 const labsContainer = document.querySelector(".labs");
 labsContainer.innerHTML = labs.join("\n");
+
+let coverPageContainer = labsContainer.querySelector(":root div:first-of-type");
+
+let versionSpan = document.createElement("span");
+versionSpan.className = 'version';
+versionSpan.innerHTML = MATERIAL_VERSION;
+
+coverPageContainer.appendChild(versionSpan);

--- a/src/labs/labs.js
+++ b/src/labs/labs.js
@@ -8,7 +8,7 @@ labsContainer.innerHTML = labs.join("\n");
 let coverPageContainer = labsContainer.querySelector(":root div:first-of-type");
 
 let versionSpan = document.createElement("span");
-versionSpan.className = 'version';
+versionSpan.className = "version";
 versionSpan.innerHTML = MATERIAL_VERSION;
 
 coverPageContainer.appendChild(versionSpan);


### PR DESCRIPTION
Add a `span` with class "version" to the first `div` of the Labs handbook.
Add CSS style for this `span`.

Fixes #53