### PR TITLE
✨ display training title where relevant

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
         width="180px"
         src="slides/assets/zenika-logo-red-no-shadow-no-text.png"
       />
+      <h1>{Titre de la Formation}</h1>
     </div>
     <div class="links">
       <div class="link"><a href="slides.html#/">👩‍🏫 Slides</a></div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,5 @@
 import "./index.css";
-import slidesContent from "training-material/Slides/slides.json";
-
-const convertTextToHtml = document.createElement("div");
-convertTextToHtml.innerHTML = slidesContent[0];
-
-const trainingTitle = convertTextToHtml.querySelector(
-  "section h1:first-of-type"
-).textContent;
+import { trainingTitle } from "./title.js";
 
 document.title = trainingTitle + " 🎓";
 const pageTitle = document.querySelector(

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,12 @@ import slidesContent from "training-material/Slides/slides.json";
 const convertTextToHtml = document.createElement("div");
 convertTextToHtml.innerHTML = slidesContent[0];
 
-const trainingTitle = convertTextToHtml.querySelector("section h1:first-of-type").textContent;
+const trainingTitle = convertTextToHtml.querySelector(
+  "section h1:first-of-type"
+).textContent;
 
 document.title = trainingTitle + " 🎓";
-const pageTitle = document.querySelector(":root div:first-of-type h1:first-of-type");
+const pageTitle = document.querySelector(
+  ":root div:first-of-type h1:first-of-type"
+);
 pageTitle.textContent = trainingTitle;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,11 @@
 import "./index.css";
+import slidesContent from "training-material/Slides/slides.json";
+
+const convertTextToHtml = document.createElement("div");
+convertTextToHtml.innerHTML = slidesContent[0];
+
+const trainingTitle = convertTextToHtml.querySelector("section h1:first-of-type").textContent;
+
+document.title = trainingTitle + " 🎓";
+const pageTitle = document.querySelector(":root div:first-of-type h1:first-of-type");
+pageTitle.textContent = trainingTitle;

--- a/src/labs/labs.js
+++ b/src/labs/labs.js
@@ -1,6 +1,7 @@
 import "prismjs/themes/prism.css";
 import "./labs.css";
 import labs from "training-material/CahierExercices/parts.json";
+import slidesContent from "training-material/Slides/slides.json";
 
 const labsContainer = document.querySelector(".labs");
 labsContainer.innerHTML = labs.join("\n");
@@ -12,3 +13,12 @@ versionSpan.className = "version";
 versionSpan.innerHTML = MATERIAL_VERSION;
 
 coverPageContainer.appendChild(versionSpan);
+
+const convertTextToHtml = document.createElement("div");
+convertTextToHtml.innerHTML = slidesContent[0];
+
+const trainingTitle = convertTextToHtml.querySelector("section h1:first-of-type").textContent;
+
+document.title = trainingTitle + " - Labs 👩‍🔬";
+const coverPageTitle = labsContainer.querySelector(":root div:first-of-type h1:first-of-type");
+coverPageTitle.textContent = trainingTitle;

--- a/src/labs/labs.js
+++ b/src/labs/labs.js
@@ -17,8 +17,12 @@ coverPageContainer.appendChild(versionSpan);
 const convertTextToHtml = document.createElement("div");
 convertTextToHtml.innerHTML = slidesContent[0];
 
-const trainingTitle = convertTextToHtml.querySelector("section h1:first-of-type").textContent;
+const trainingTitle = convertTextToHtml.querySelector(
+  "section h1:first-of-type"
+).textContent;
 
 document.title = trainingTitle + " - Labs 👩‍🔬";
-const coverPageTitle = labsContainer.querySelector(":root div:first-of-type h1:first-of-type");
+const coverPageTitle = labsContainer.querySelector(
+  ":root div:first-of-type h1:first-of-type"
+);
 coverPageTitle.textContent = trainingTitle;

--- a/src/labs/labs.js
+++ b/src/labs/labs.js
@@ -1,7 +1,7 @@
 import "prismjs/themes/prism.css";
 import "./labs.css";
 import labs from "training-material/CahierExercices/parts.json";
-import slidesContent from "training-material/Slides/slides.json";
+import { trainingTitle } from "../title.js";
 
 const labsContainer = document.querySelector(".labs");
 labsContainer.innerHTML = labs.join("\n");
@@ -13,13 +13,6 @@ versionSpan.className = "version";
 versionSpan.innerHTML = MATERIAL_VERSION;
 
 coverPageContainer.appendChild(versionSpan);
-
-const convertTextToHtml = document.createElement("div");
-convertTextToHtml.innerHTML = slidesContent[0];
-
-const trainingTitle = convertTextToHtml.querySelector(
-  "section h1:first-of-type"
-).textContent;
 
 document.title = trainingTitle + " - Labs 👩‍🔬";
 const coverPageTitle = labsContainer.querySelector(

--- a/src/slides/slides.js
+++ b/src/slides/slides.js
@@ -10,7 +10,8 @@ import slidesContent from "training-material/Slides/slides.json";
 const slideContainer = document.querySelector(".slides");
 slideContainer.innerHTML = slidesContent.join("\n");
 
-const trainingTitle = slideContainer.querySelector("section h1:first-of-type").textContent;
+const trainingTitle = slideContainer.querySelector("section h1:first-of-type")
+  .textContent;
 document.title = trainingTitle + " - Slides 👩‍🏫";
 
 for (let versionContainer of slideContainer.getElementsByClassName("version")) {

--- a/src/slides/slides.js
+++ b/src/slides/slides.js
@@ -6,12 +6,11 @@ import "reveal.js/dist/reveal.css";
 import "prismjs/themes/prism.css";
 import "./slides.css";
 import slidesContent from "training-material/Slides/slides.json";
+import { trainingTitle } from "../title.js";
 
 const slideContainer = document.querySelector(".slides");
 slideContainer.innerHTML = slidesContent.join("\n");
 
-const trainingTitle = slideContainer.querySelector("section h1:first-of-type")
-  .textContent;
 document.title = trainingTitle + " - Slides 👩‍🏫";
 
 for (let versionContainer of slideContainer.getElementsByClassName("version")) {

--- a/src/slides/slides.js
+++ b/src/slides/slides.js
@@ -10,6 +10,9 @@ import slidesContent from "training-material/Slides/slides.json";
 const slideContainer = document.querySelector(".slides");
 slideContainer.innerHTML = slidesContent.join("\n");
 
+const trainingTitle = slideContainer.querySelector("section h1:first-of-type").textContent;
+document.title = trainingTitle + " - Slides 👩‍🏫";
+
 for (let versionContainer of slideContainer.getElementsByClassName("version")) {
   versionContainer.innerHTML = MATERIAL_VERSION;
 }

--- a/src/title.js
+++ b/src/title.js
@@ -1,0 +1,10 @@
+import slidesContent from "training-material/Slides/slides.json";
+
+const convertTextToHtml = document.createElement("div");
+convertTextToHtml.innerHTML = slidesContent[0];
+
+const trainingTitle = convertTextToHtml.querySelector(
+  "section h1:first-of-type"
+).textContent;
+
+export { trainingTitle };


### PR DESCRIPTION
Here is a proposal to update Slides, Labs & index with the training material title (rather than always using "Zenika Formation").
The Labs cover page also gets updated with the material title, rather than "{Titre de la Formation}".

Let me know what you think about this.