### PR TITLE
change math delimiter for math plugin

### DIFF
--- a/src/slides/slides.js
+++ b/src/slides/slides.js
@@ -30,4 +30,7 @@ reveal.initialize({
   width: 1420,
   height: 800,
   plugins: [revealPluginMathJax, revealPluginNotes, revealPluginZoom],
+  math: {
+    tex2jax: { inlineMath: [["\\(", "\\)"]] },
+  },
 });


### PR DESCRIPTION
When writing multiple `$` in the same line, the text in-between gets interpreted as Math formula.
This delimiter is too generic.
Configure math plugin to only use `\(...\)`.

Example:

    Inline is interpreted: `echo "${MY_VAR} is ${VAR_STATE}"`

    Block is OK:

    ```shell
    echo "${MY_VAR} is ${VAR_STATE}"
    ```

"Old" framework:
![image](https://user-images.githubusercontent.com/175128/105831292-d1071e00-5fc6-11eb-96da-790a8da674c6.png)
Sensei:
![image](https://user-images.githubusercontent.com/175128/105831351-e2502a80-5fc6-11eb-846d-503938451360.png)
With this ix: 
![image](https://user-images.githubusercontent.com/175128/105831641-4246d100-5fc7-11eb-8ac2-6e5451b6825a.png)
