### PR TITLE
🐛 fix pdf command on windows

### DIFF
--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -83,10 +83,11 @@ function help() {
 function pdfSlides(trainingName) {
   return new Promise((resolve, reject) => {
     const child = spawn(
-      path.resolve(
-        path.join(__dirname, "../src/pdf/node_modules/.bin/decktape")
-      ),
+      "node",
       [
+        path.resolve(
+          path.join(__dirname, "../src/pdf/node_modules/decktape/decktape.js")
+        ),
         "reveal",
         "-p",
         "0",

--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -82,21 +82,18 @@ function help() {
 
 function pdfSlides(trainingName) {
   return new Promise((resolve, reject) => {
-    const child = spawn(
-      "node",
-      [
-        path.resolve(
-          path.join(__dirname, "../src/pdf/node_modules/decktape/decktape.js")
-        ),
-        "reveal",
-        "-p",
-        "0",
-        "--size",
-        "1420x800",
-        `file:${path.resolve("./dist/slides.html")}`,
-        `./pdf/Zenika-${trainingName}-Slides.pdf`,
-      ]
-    );
+    const child = spawn("node", [
+      path.resolve(
+        path.join(__dirname, "../src/pdf/node_modules/decktape/decktape.js")
+      ),
+      "reveal",
+      "-p",
+      "0",
+      "--size",
+      "1420x800",
+      `file:${path.resolve("./dist/slides.html")}`,
+      `./pdf/Zenika-${trainingName}-Slides.pdf`,
+    ]);
 
     child.stdout.on("data", function (data) {
       process.stdout.write(data);


### PR DESCRIPTION
This is a more cross-platformy way to run decktape. Even better would have been to run decktape without spawning a process, directly through a JS API, but decktape does not have one.