### PR TITLE
Do not force table cells text alignment in labs.

### DIFF
--- a/src/labs/labs.css
+++ b/src/labs/labs.css
@@ -283,14 +283,12 @@ table tr:nth-child(2n) {
 table tr th {
   font-weight: bold;
   border: 1px solid #cccccc;
-  text-align: left;
   margin: 0;
   padding: 6px 13px;
 }
 
 table tr td {
   border: 1px solid #cccccc;
-  text-align: left;
   margin: 0;
   padding: 6px 13px;
 }


### PR DESCRIPTION
This allow to set it as HTML attribute through markdown