### PR TITLE
👽 support both 'ressources' and 'resources' folders for custom css

### DIFF
--- a/bin/webpack.config.js
+++ b/bin/webpack.config.js
@@ -147,6 +147,8 @@ module.exports = (env = {}) => {
       fallback: {
         "training-material/Workbook/parts.json":
           "training-material/CahierExercices/parts.json",
+        "training-material/Slides/resources/custom.css":
+          "training-material/Slides/ressources/custom.css",
         "training-material/Slides/ressources/custom.css": false,
       },
     },

--- a/src/slides/slides.js
+++ b/src/slides/slides.js
@@ -5,7 +5,7 @@ import revealPluginMathJax from "reveal.js/plugin/math/math.js";
 import "reveal.js/dist/reveal.css";
 import "prismjs/themes/prism.css";
 import "./slides.css";
-import "training-material/Slides/ressources/custom.css";
+import "training-material/Slides/resources/custom.css";
 import slidesContent from "training-material/Slides/slides.json";
 import { trainingTitle } from "../title.js";
 


### PR DESCRIPTION
Because of Zenika-Training/training-template#150