### PR TITLE
🐛 fix .element for self-closing tags

### DIFF
--- a/src/loaders/revealjs-loader.js
+++ b/src/loaders/revealjs-loader.js
@@ -147,12 +147,16 @@ function slidify(markdown, options) {
   }
 
   // Support for the <!-- .element: --> syntax from Reveal (see https://revealjs.com/markdown/#element-attributes)
-  markdownSections = markdownSections.replace(
-    /(<!--\s*\.element:?(["\w \t=:;%-]+)-->\s*)<([^>]+)>/g,
-    "$1<$3 $2>"
-  );
+  markdownSections = handleDotElementRevealSyntax(markdownSections);
 
   return markdownSections;
+}
+
+function handleDotElementRevealSyntax(markdownSections) {
+  return markdownSections.replace(
+    /(<!--\s*\.element:?(["\w \t=:;%-]+)-->\s*)<([^>\/]+)/g,
+    "$1<$3 $2"
+  );
 }
 
 function footer({ chapterIndex, slideIndex, materialVersion }) {
@@ -242,3 +246,5 @@ function getSlidifyOptions(options) {
 
   return options;
 }
+
+module.exports.handleDotElementRevealSyntax = handleDotElementRevealSyntax;

--- a/src/loaders/revealjs-loader.test.js
+++ b/src/loaders/revealjs-loader.test.js
@@ -1,0 +1,54 @@
+const assert = require("assert");
+const { handleDotElementRevealSyntax } = require("./revealjs-loader");
+
+{
+  const actual = handleDotElementRevealSyntax(`
+    <!-- .element: attr="value" -->
+    <tag>
+  `);
+  const expected = /<tag\s+attr="value"\s*>/;
+  assert.match(
+    actual,
+    expected,
+    "dot element reveal syntax handler does not support original tag without attributes"
+  );
+}
+
+{
+  const actual = handleDotElementRevealSyntax(`
+    <!-- .element: attr3="value" -->
+    <tag attr1="value" attr2="value">
+  `);
+  const expected = /<tag\s+attr1="value"\s+attr2="value"\s+attr3="value"\s*>/;
+  assert.match(
+    actual,
+    expected,
+    "dot element reveal syntax handler does not support original tag with attributes"
+  );
+}
+
+{
+  const actual = handleDotElementRevealSyntax(`
+    <!-- .element: attr="value" -->
+    <tag/>
+  `);
+  const expected = /<tag\s+attr="value"\s*\/>/;
+  assert.match(
+    actual,
+    expected,
+    "dot element reveal syntax handler does not support original self-closing tag without attributes"
+  );
+}
+
+{
+  const actual = handleDotElementRevealSyntax(`
+    <!-- .element: attr2="value" -->
+    <tag attr1="value"/>
+  `);
+  const expected = /<tag\s+attr1="value"\s+attr2="value"\s*\/>/;
+  assert.match(
+    actual,
+    expected,
+    "dot element reveal syntax handler does not support original self-closing tag with attributes"
+  );
+}


### PR DESCRIPTION
The syntax `<!-- .element: attr="value"--><img/>`, in slide content, was incorrectly transformed into `<img/ attr="value">` which would raise a parser error in html-loader when building in production mode.

This syntax is not very useful as it could easily be written as `<img attr="value"/>` instead, but since it's valid Markdown/HTML and an occurence was found in real-world material (see [here](https://github.com/Zenika/formation-ddd/blob/cc343167dec3a972907d96fef0f5571363ace8bb/Slides/3%20-%20ddd%20tactique%20-%20domain%20-%20avant-propos.md?plain=1#L76-L77)), we should handle it properly.

Since the problem only comes up in production mode, I've decided to switch all build tests to the production mode (with performance hints turned off to avoid asset size warnings).