### PR TITLE
🚑 fix live reload

### DIFF
--- a/bin/sensei.js
+++ b/bin/sensei.js
@@ -42,6 +42,8 @@ async function serve(buildOptions, serveOptions) {
       devMiddleware: {
         stats: { children: true, warnings: true, errors: true },
       },
+      // Disables HMR, enables live reload, see https://webpack.js.org/configuration/dev-server/#devserverhot
+      hot: false,
     },
     webpack(webpackConfig(buildOptions))
   );


### PR DESCRIPTION
Attempt to fix #131.

Disable the hot module replacement feature of webpack dev server, which does not seem to work in our case (maybe because of #125?). This makes dev server use its "classic" live reload feature (full page reload) instead, which works.