### PR TITLE
🐛 fix compile error when html in title

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="<%= htmlWebpackPlugin.options.language %>">
+<html lang="<%- htmlWebpackPlugin.options.language %>">
   <head>
     <meta charset="UTF-8" />
-    <title><%= require('./content.js').title %> 🎓</title>
+    <title><%- require('./content.js').title %> 🎓</title>
   </head>
 
   <body>
     <div>
       <img
         width="180px"
-        src="<%= require('./assets/zenika-logo-monogram.png') %>"
+        src="<%- require('./assets/zenika-logo-monogram.png') %>"
       />
       <h1><%= require('./content.js').title %></h1>
     </div>
@@ -17,7 +17,7 @@
       <div class="link">
         <a href="slides.html#/">👩‍🏫 Slides</a>
         <a
-          href="pdf/Zenika-<%= htmlWebpackPlugin.options.trainingSlug %>-Slides.pdf"
+          href="pdf/Zenika-<%- htmlWebpackPlugin.options.trainingSlug %>-Slides.pdf"
           class="link-pdf"
           >📄 PDF</a
         >
@@ -25,7 +25,7 @@
       <div class="link">
         <a href="labs.html">👩‍🔬 Labs</a>
         <a
-          href="pdf/Zenika-<%= htmlWebpackPlugin.options.trainingSlug %>-Workbook.pdf"
+          href="pdf/Zenika-<%- htmlWebpackPlugin.options.trainingSlug %>-Workbook.pdf"
           class="link-pdf"
           >📄 PDF</a
         >

--- a/src/app/labs/labs.html
+++ b/src/app/labs/labs.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="<%= htmlWebpackPlugin.options.language %>">
+<html lang="<%- htmlWebpackPlugin.options.language %>">
   <head>
     <meta charset="UTF-8" />
-    <title><%= require('./content.js').title %> - Labs 👩‍🔬</title>
+    <title><%- require('./content.js').title %> - Labs 👩‍🔬</title>
   </head>
   <body>
     <div
       id="labs-container"
       class="labs"
-      data-title="<%= require('./content.js').title %>"
-      data-version="<%= htmlWebpackPlugin.options.materialVersion %>"
+      data-title="<%- require('./content.js').title %>"
+      data-version="<%- htmlWebpackPlugin.options.materialVersion %>"
     >
       <%= require('./content.js').content %>
     </div>

--- a/src/app/slides/slides.html
+++ b/src/app/slides/slides.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="<%= htmlWebpackPlugin.options.language %>">
+<html lang="<%- htmlWebpackPlugin.options.language %>">
   <head>
     <meta charset="UTF-8" />
-    <title><%= require('./content.js').title %> - Slides 👩‍🏫</title>
+    <title><%- require('./content.js').title %> - Slides 👩‍🏫</title>
   </head>
   <body>
     <div class="reveal">

--- a/src/build/webpack.config.test.js
+++ b/src/build/webpack.config.test.js
@@ -47,6 +47,11 @@ testCompilation(
   { ignoreWarnings: [TITLE_NOT_FOUND_WARNING] }
 );
 
+testCompilation("one slide with a title including HTML", {
+  slides: [{ file: "img.md", content: '# <img src="../assets/img.png">' }],
+  assets: [{ file: "img.png" }],
+});
+
 testCompilation("first chapter of training material template", {
   slides: [
     {


### PR DESCRIPTION
Title is now HTML-escaped before being interpolated into the `data-title` attribute in `labs.html`. Also HTML-escaped other interpolations, where relevant. See #138. Added a test to prove the fix.