### PR TITLE
Fix 'page-tp' when solo page in file

### DIFF
--- a/src/app/slides/slides.css
+++ b/src/app/slides/slides.css
@@ -262,17 +262,17 @@ body:lang(en) {
   background-size: 55%;
 }
 
-.reveal section [class^="page-tp"]:before {
+.reveal section[class^="page-tp"]:before {
   content: "";
   display: inline-block;
   vertical-align: middle;
   height: 80%;
 }
-.reveal section [class^="page-tp"] {
+.reveal section[class^="page-tp"] {
   background: white top center no-repeat url("./assets/Programming-pana.svg");
   background-size: 48%;
 }
-.reveal section [class^="page-tp"]:after {
+.reveal section[class^="page-tp"]:after {
   display: block;
   color: var(--zenika-red);
   font-size: 50px;


### PR DESCRIPTION
When multiple pages in file, each slide is a 'section' under a 'section[class=stack]',
but when only one page, the slide is not under a 'section' and the CSS rule didn't handle this case

Ping @moreau-nicolas

Example https://github.com/Zenika/formation-craftsmanship-sensibilisation/blob/update-template/Slides/07_kata_pingpong.md?plain=1 (using `page-demo` as a workaround)