### PR TITLE
🐛 dont generate header ids to avoid conflict with section ids

### DIFF
--- a/src/build/loaders/revealjs-loader.js
+++ b/src/build/loaders/revealjs-loader.js
@@ -234,6 +234,7 @@ function createMarkdownSlide(content, options) {
       const prismLang = Prism.languages[lang] || Prism.languages.clike;
       return Prism.highlight(code, prismLang);
     },
+    headerIds: false,
   });
   return marked(content); //'<script type="text/template">' + marked(content) + "</script>";
 }


### PR DESCRIPTION
Minimize impact of #145 on existing trainings.