### PR TITLE
Workaround for git error 'unsafe repository'

### DIFF
--- a/src/build/webpack.config.js
+++ b/src/build/webpack.config.js
@@ -169,8 +169,11 @@ function composeMaterialVersion(material) {
 
   let commitHash = "";
   try {
+    // 'safe.directory=*' is needed to avoid error 'unsafe repository', see https://github.com/Zenika/sensei/pull/154
     commitHash = childProcess
-      .execSync("git rev-parse --short HEAD", { cwd: material })
+      .execSync("git -c safe.directory=* rev-parse --short HEAD", {
+        cwd: material,
+      })
       .toString()
       .trim();
   } catch (err) {


### PR DESCRIPTION
```shell
$ docker container run --pull always --rm --volume $(CURDIR):/$(TRAINING_NAME) --workdir /$(TRAINING_NAME) --cap-add=SYS_ADMIN zenika/sensei pdf

fatal: unsafe repository ('/training-terraform' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /training-terraform
```

Do not understand why this happen as the folder is owned by user `chrome` executing `git`. (Maybe an issue with the `cwd`?)
This problem only occurs for Apple M1 and the arm64 build of sensei.
https://zenika.slack.com/archives/C063LTVU7/p1655282726494619

Ping @bgauduch 

Built [`zenika/sensei:arm64`](https://hub.docker.com/layers/sensei/zenika/sensei/arm64/images/sha256-9cbde1b23b5d48dcd8f48ff50009912194d49f882a9ac7f5d0cdf53a9f4920ee?context=explore) with this fix.