### PR TITLE
Replace 'script' tags after Markdown rendering

### DIFF
--- a/example/Slides/chapter_1.md
+++ b/example/Slides/chapter_1.md
@@ -24,3 +24,33 @@
 ## Slide 2
 
 A slide with just text and no bullet points? How unusual!
+
+
+
+## Slide 3
+
+<span/>
+
+```
+# No language
+<script>
+window.alert("test");
+</script>
+```
+```html
+<!-- HTML -->
+<script>
+window.alert("test");
+</script>
+```
+```java
+// Java
+<script>
+window.alert("test");
+</script>
+```
+
+Direct:
+<script>
+window.alert("test");
+</script>

--- a/src/build/loaders/revealjs-loader.js
+++ b/src/build/loaders/revealjs-loader.js
@@ -58,7 +58,8 @@ var DEFAULT_SLIDE_SEPARATOR = "^\r?\n---\r?\n$",
   DEFAULT_ELEMENT_ATTRIBUTES_SEPARATOR = "\\.element\\s*?(.+?)$",
   DEFAULT_SLIDE_ATTRIBUTES_SEPARATOR = "\\.slide:\\s*?(\\S.+?)$";
 
-var SCRIPT_END_PLACEHOLDER = "__SCRIPT_END__";
+var SCRIPT_START_PLACEHOLDER = "__SCRIPT_START__",
+  SCRIPT_END_PLACEHOLDER = "__SCRIPT_END__";
 
 function slidify(markdown, options) {
   options = getSlidifyOptions(options);
@@ -213,10 +214,6 @@ function createMarkdownSlide(content, options) {
       "</aside>";
   }
 
-  // prevent script end tags in the content from interfering
-  // with parsing
-  content = content.replace(/<\/script>/g, SCRIPT_END_PLACEHOLDER);
-
   marked.use({
     renderer: {
       html(_html) {
@@ -236,7 +233,13 @@ function createMarkdownSlide(content, options) {
     },
     headerIds: false,
   });
-  return marked(content); //'<script type="text/template">' + marked(content) + "</script>";
+  content = marked(content);
+
+  // prevent script tags in plain markdown
+  content = content.replace(/<script>/g, SCRIPT_START_PLACEHOLDER);
+  content = content.replace(/<\/script>/g, SCRIPT_END_PLACEHOLDER);
+
+  return content;
 }
 
 function getSlidifyOptions(options) {


### PR DESCRIPTION
Fixes issue #144

Replace both start and end tags

Result:
![image](https://user-images.githubusercontent.com/175128/176870678-9c7fd7d0-d215-4df4-9947-6fbdd494114f.png)
