### PR TITLE
FIX #176 - disable safe directory warning globally for git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM zenika/alpine-chrome:with-puppeteer
 
 USER root
 
+RUN git config --system --add safe.directory '*'
+
 RUN apk add --no-cache ttf-liberation
 
 WORKDIR /app

--- a/src/build/webpack.config.js
+++ b/src/build/webpack.config.js
@@ -183,9 +183,8 @@ function composeMaterialVersion(material) {
 
   let commitHash = "";
   try {
-    // 'safe.directory=*' is needed to avoid error 'unsafe repository', see https://github.com/Zenika/sensei/pull/154
     commitHash = childProcess
-      .execSync("git -c safe.directory=* rev-parse --short HEAD", {
+      .execSync("git rev-parse --short HEAD", {
         cwd: material,
         env: { LANG: "C" } /* ensure language of output to catch error */,
       })


### PR DESCRIPTION
FIX #176 

Allow any directory to have a different owner than the container's USER (chrome - 501). 

Git's behaviour has changed in v2.35.1. See [here](https://github.blog/2022-04-12-git-security-vulnerability-announced/).

The option had to be put on any user (system) otherwise it did not work - git knows why.
Setting this option globally for the chrome user only did not fix the issue.

The same behavior is encountered on various SO threads, so I guess the option is too fresh in git and might fail somehow when set for a user..

Setting this option on system (ie. any user) makes it behave as it should.

Had to set the folder to any (*) because the documentation example of the docker command set a non-consistant volume path.