### PR TITLE
:memo: add instruction to use native sensei to generate pdf on Mac Arm {M1,M2}

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Therefore it is recommended to clone the training repository in the Linux filesy
 > correctly.
 
 ⚠️ On Mac M1 or M2, you need to follow special steps to enable PDF generation.
-You must do this before the `npm install`, otherwise you will have an unused version of chromium installed in `~/.cache/puppeteer`
+You must do this before the `npm install`, otherwise you will have an unused version of chromium installed in `~/.cache/puppeteer`.
 
 ```
 # Install chromium without Mac OS Quarantine to allow puppeteer to launch it

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ Therefore it is recommended to clone the training repository in the Linux filesy
 > installing packages from GitHub, resulting in failures to update sensei
 > correctly.
 
+⚠️ On Mac M1 or M2, you need to follow special steps to enable PDF generation:
+
+```
+# Install chromium without Mac OS Quarantine to allow puppeteer to launch it
+brew install --cask chromium --no-quarantine
+# Put these variables export in your .bashrc or .zshrc to make sure puppeteer use the right chromium
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_EXECUTABLE_PATH=`which chromium`
+```
+
 ## Usage
 
 ### Help
@@ -79,16 +89,6 @@ Run `sensei --help` for available commands and options.
   `Workbook/workbook.json`)
 - Run `sensei pdf`
 - PDFs are generated inside `pdf` folder
-
-⚠️ If running native sensei on Mac M1, you need to follow special steps:
-
-```
-# Install chromium without Mac OS Quarantine to allow puppeteer to launch it
-brew install --cask chromium --no-quarantine
-# Put these variables export in your .bashrc or .zshrc to make sure puppeteer use the right chromium
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-export PUPPETEER_EXECUTABLE_PATH=`which chromium`
-```
 
 ### Serving the slides and labs
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Therefore it is recommended to clone the training repository in the Linux filesy
 > installing packages from GitHub, resulting in failures to update sensei
 > correctly.
 
-⚠️ On Mac M1 or M2, you need to follow special steps to enable PDF generation:
+⚠️ On Mac M1 or M2, you need to follow special steps to enable PDF generation.
+You must do this before the `npm install`, otherwise you will have an unused version of chromium installed in `~/.cache/puppeteer`
 
 ```
 # Install chromium without Mac OS Quarantine to allow puppeteer to launch it

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Run `sensei --help` for available commands and options.
 - Run `sensei pdf`
 - PDFs are generated inside `pdf` folder
 
+⚠️ If running native sensei on Mac M1, you need to follow special steps:
+
+```
+# Install chromium without Mac OS Quarantine to allow puppeteer to launch it
+brew install --cask chromium --no-quarantine
+# Put these variables export in your .bashrc or .zshrc to make sure puppeteer use the right chromium
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_EXECUTABLE_PATH=`which chromium`
+```
+
 ### Serving the slides and labs
 
 - `cd` into a training material folder (must have `Slides/slides.json` and


### PR DESCRIPTION
Hi!

I did not find instructions on how to use `sensei` natively on Mac Arm to generate PDF, so I added some instructions that worked for me.