### PR TITLE
Support natif des blocs aside md-extended dans le workbook

### DIFF
--- a/src/app/labs/labs.css
+++ b/src/app/labs/labs.css
@@ -268,6 +268,29 @@ blockquote > :last-child {
   margin-bottom: 0;
 }
 
+/* Strigo md-extended `> aside positive/neutral/negative` — classes applied by labs.js transformer */
+blockquote.aside {
+  border-left: 4px solid;
+  padding: 10px 16px;
+  margin: 16px 0;
+  color: inherit; /* override the #777 default on blockquote */
+}
+
+blockquote.aside-positive {
+  border-left-color: var(--zenika-green, #00eb84);
+  background-color: rgba(0, 235, 132, 0.07);
+}
+
+blockquote.aside-neutral {
+  border-left-color: var(--zenika-blue, #4ca8e7);
+  background-color: rgba(76, 168, 231, 0.07);
+}
+
+blockquote.aside-negative {
+  border-left-color: var(--zenika-red, #ee2238);
+  background-color: rgba(238, 34, 56, 0.07);
+}
+
 table {
   padding: 0;
 }

--- a/src/app/labs/labs.js
+++ b/src/app/labs/labs.js
@@ -1,6 +1,23 @@
 import "prismjs/themes/prism.css";
 import "./labs.css";
+// Optional formation-level overrides — resolved to false by webpack if absent (see webpack.config.js fallback)
+import "training-material/Workbook/resources/custom.css";
+import "training-material/Workbook/resources/custom.js";
 import { title } from "./content.js";
+
+// Strigo md-extended renders `> aside positive/neutral/negative` as colored blocks natively.
+// marked outputs a plain <blockquote> — this transformer applies the same classes so PDF and web match.
+document.querySelectorAll("blockquote").forEach(function (bq) {
+  const first = bq.querySelector("p:first-child");
+  if (!first) return;
+  const m = first.textContent.match(/^aside (positive|neutral|negative)\s*/);
+  if (!m) return;
+  bq.classList.add("aside", "aside-" + m[1]);
+  first.innerHTML = first.innerHTML
+    .replace(/^aside (positive|neutral|negative)\s*/, "")
+    .trimStart();
+  if (!first.textContent.trim()) first.remove();
+});
 
 const labsContainer = document.getElementById("labs-container");
 const { version } = labsContainer.dataset;

--- a/src/build/webpack.config.js
+++ b/src/build/webpack.config.js
@@ -124,6 +124,12 @@ module.exports = (env = {}, argv = {}) => {
         "training-material/Slides/resources/custom.css":
           "training-material/Slides/ressources/custom.css",
         "training-material/Slides/ressources/custom.css": false,
+        "training-material/Workbook/resources/custom.css":
+          "training-material/Workbook/ressources/custom.css",
+        "training-material/Workbook/ressources/custom.css": false,
+        "training-material/Workbook/resources/custom.js":
+          "training-material/Workbook/ressources/custom.js",
+        "training-material/Workbook/ressources/custom.js": false,
       },
     },
     output: {


### PR DESCRIPTION
Strigo rend nativement` > aside positive/neutral/negative` en blocs colorés. Sensei produisait jusqu'ici un blockquote brut avec le texte "aside …" visible dans les PDF et la version web.

- labs.css : styles blockquote.aside-* alignés sur les couleurs Zenika (--zenika-green/blue/red)
- labs.js : transformateur DOM qui détecte la syntaxe aside et applique les classes au rendu de marked
- webpack.config.js : fallbacks Workbook/resources/custom.css et custom.js pour les formations qui ont des besoins de personnalisation spécifiques